### PR TITLE
Thumbnail fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ Unreleased
 - Changed:
 - Fixed:
 
+3.0.6 - 2025-09-02
+- Fixed: Portadas embebidas de forma robusta aunque `yt-dlp` no entregue `thumbnail` plano; ahora se resuelve desde `thumbnails` y, si falta, se usa fallback `i.ytimg.com/…/hqdefault.jpg`.
+- Fixed: Soporte de portadas servidas como WEBP convirtiéndolas a JPEG antes de incrustar (Mutagen/FLAC).
+- Added: Trazas DEBUG detalladas para diagnóstico de portadas (URL resuelta, respuesta HTTP, dimensiones/bytes procesados y `pictures` tras guardar).
+- Changed: Descarga de portada con User‑Agent para evitar bloqueos de CDN.
+
 3.0.5 - 2025-09-02
 - Fixed: `PlaylistMonitor.get_playlist_videos()` soporta stdout con JSON de video único (compat con tests y casos edge).
 - Fixed: CI fallos por parser — tolerancia de formatos de salida (`-J --flat-playlist`) y fallback por líneas.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ Unreleased
 - Changed:
 - Fixed:
 
+3.0.7 - 2025-09-02
+- Fixed: Cumplimiento flake8 E501 (línea larga) en `downloader.py` al envolver la URL de fallback de thumbnail; CI verde de nuevo.
+
 3.0.6 - 2025-09-02
 - Fixed: Portadas embebidas de forma robusta aunque `yt-dlp` no entregue `thumbnail` plano; ahora se resuelve desde `thumbnails` y, si falta, se usa fallback `i.ytimg.com/…/hqdefault.jpg`.
 - Fixed: Soporte de portadas servidas como WEBP convirtiéndolas a JPEG antes de incrustar (Mutagen/FLAC).

--- a/src/youtube_watcher/downloader.py
+++ b/src/youtube_watcher/downloader.py
@@ -66,7 +66,9 @@ class YouTubeDownloader:
                             break
             if not thumbnail_url and video_data.get("id"):
                 # Fallback estable de YouTube
-                thumbnail_url = f"https://i.ytimg.com/vi/{video_data['id']}/hqdefault.jpg"
+                thumbnail_url = (
+                    f"https://i.ytimg.com/vi/{video_data['id']}/hqdefault.jpg"
+                )
 
         logger.debug(
             "Thumbnail URL resolved for '%s': %s", title, thumbnail_url or "<none>"


### PR DESCRIPTION
3.0.7 - 2025-09-02
- Fixed: Cumplimiento flake8 E501 (línea larga) en `downloader.py` al envolver la URL de fallback de thumbnail; CI verde de nuevo.

3.0.6 - 2025-09-02
- Fixed: Portadas embebidas de forma robusta aunque `yt-dlp` no entregue `thumbnail` plano; ahora se resuelve desde `thumbnails` y, si falta, se usa fallback `i.ytimg.com/…/hqdefault.jpg`.
- Fixed: Soporte de portadas servidas como WEBP convirtiéndolas a JPEG antes de incrustar (Mutagen/FLAC).
- Added: Trazas DEBUG detalladas para diagnóstico de portadas (URL resuelta, respuesta HTTP, dimensiones/bytes procesados y `pictures` tras guardar).
- Changed: Descarga de portada con User‑Agent para evitar bloqueos de CDN.